### PR TITLE
add SOCKS5 Proxy and Bypass Addresses to application settings.

### DIFF
--- a/app/src/main/java/com/antest1/kcanotify/KcaConstants.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaConstants.java
@@ -269,6 +269,7 @@ public final class KcaConstants {
     public static final String PREF_AKASHI_FILTERLIST = "akashi_filterlist";
     public static final String PREF_FAIRY_ICON = "fairy_icon";
     public static final String PREF_APK_DOWNLOAD_SITE = "apk_download_site";
+    public static final String PREF_VPN_BYPASS_ADDRESS = "bypass_address";
 
     public static final String[] PREF_ARRAY = {
             PREF_CHECK_UPDATE,
@@ -292,7 +293,8 @@ public final class KcaConstants {
             PREF_AKASHI_STARLIST,
             PREF_AKASHI_FILTERLIST,
             PREF_FAIRY_ICON,
-            PREF_APK_DOWNLOAD_SITE
+            PREF_APK_DOWNLOAD_SITE,
+            PREF_VPN_BYPASS_ADDRESS
     };
 
     public static final List<String> PREFS_LIST = Arrays.asList(PREF_ARRAY);

--- a/app/src/main/java/com/antest1/kcanotify/SettingActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/SettingActivity.java
@@ -42,6 +42,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -59,6 +60,7 @@ import static com.antest1.kcanotify.KcaConstants.PREF_KCA_EXP_VIEW;
 import static com.antest1.kcanotify.KcaConstants.PREF_KCA_LANGUAGE;
 import static com.antest1.kcanotify.KcaConstants.PREF_KCA_SEEK_CN;
 import static com.antest1.kcanotify.KcaConstants.PREF_OVERLAY_SETTING;
+import static com.antest1.kcanotify.KcaConstants.PREF_VPN_BYPASS_ADDRESS;
 import static com.antest1.kcanotify.KcaService.kca_version;
 import static com.antest1.kcanotify.KcaUtils.compareVersion;
 import static com.antest1.kcanotify.KcaUtils.getContextWithLocale;
@@ -175,6 +177,25 @@ public class SettingActivity extends AppCompatActivity {
                                 sHandler.sendMessage(sMsg);
                             }
                             Toast.makeText(context, context.getString(R.string.sa_language_changed), Toast.LENGTH_LONG).show();
+                            return true;
+                        }
+                    });
+                }
+
+                if (key.equals(PREF_VPN_BYPASS_ADDRESS)) {
+                    pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                        @Override
+                        public boolean onPreferenceChange(Preference preference, Object newValue) {
+                            if (newValue.equals(""))
+                                return true;
+                            Pattern cidrPattern = Pattern.compile("^(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])/(\\d|[1-2]\\d|3[0-2])$");
+                            String[] cidrs = ((String) newValue).split(",");
+                            for (String cidr : cidrs) {
+                                if (!cidrPattern.matcher(cidr.trim()).find()) {
+                                    Toast.makeText(context, getString(R.string.sa_bypass_list_invalid), Toast.LENGTH_LONG).show();
+                                    return false;
+                                }
+                            }
                             return true;
                         }
                     });

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -90,6 +90,8 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
     <string name="sa_overlay_ok">允许悬浮：开</string>
     <string name="sa_overlay_no">允许悬浮：关（战斗剧透会被禁用）</string>
 
+    <string name="sa_bypass_list_invalid">输入的绕行地址列表有错，请检查后重试。</string>
+
     <!-- InfoActivity Strings -->
 
     <!-- KcaService Strings -->
@@ -135,6 +137,12 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
     <string name="setting_menu_kand_desc_exp_realtime_show">在通知栏显示剩余时间</string>
     <string name="setting_menu_kand_title_game_data_down">下载游戏缓存</string>
     <string name="setting_menu_kand_desc_game_data_down">在缓存数据没有自动加载时使用</string>
+    <string name="setting_menu_kand_title_adv_network">高级网络设置</string>
+    <string name="setting_menu_kand_warn_adv_network">警告：错误的设置以下项目可能会让VPN失效。请仅在你确定每个设置项作用时更改这些设置。在更改设置之后需要重启VPN服务以使设置生效。</string>
+    <string name="setting_menu_kand_title_socks5_address">SOCKS5代理地址</string>
+    <string name="setting_menu_kand_title_socks5_port">SOCKS5代理端口</string>
+    <string name="settings_menu_kand_title_bypass_address">绕行地址</string>
+    <string name="setting_menu_kand_desc_bypass_address">使用CIDR描述不经过代理的地址，使用逗号分隔每个CIDR。</string>
 
     <string name="setting_menu_view_head">战斗剧透/任务浏览设置</string>
     <string name="setting_menu_view_title_overlay_setting">悬浮窗设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,8 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
 
     <string name="sa_language_changed">Please restart kcanotify to apply new language setting.</string>
 
+    <string name="sa_bypass_list_invalid">The bypass address list is invalid. Please double-check your input.</string>
+
     <!-- InfoActivity Strings -->
     <string name="ia_license" formatted="false" translatable="false">Copyright &#169; 2016-2017 by antest1(IE10)</string>
     <string name="ia_gpl" formatted="false" translatable="false">By using %s, you agree to the &lt;a href="http://www.gnu.org/licenses/gpl.txt"&gt;GNU General Public License 3.0&lt;/a&gt;. The whole source code is available on &lt;a href="https://github.com/antest1/kcanotify/"&gt;github repository&lt;/a&gt;.</string>
@@ -167,6 +169,12 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
     <string name="setting_menu_kand_desc_fairy_select">Select Fairy to bring with</string>
     <string name="setting_menu_kand_title_fairy_select">Select Fairy</string>
     <string name="current_fairy_changed_in_next">※ Fairy will be changed after current BattleView/QuestView ends.</string>
+    <string name="setting_menu_kand_title_adv_network">Advanced Network Settings</string>
+    <string name="setting_menu_kand_warn_adv_network">Warning: Setting these incorrectly may make VPN Service unusable. Don\'t change these options unless you know what you are doing! You need to restart VPN Service to make these options effective.</string>
+    <string name="setting_menu_kand_title_socks5_address">SOCKS5 Proxy Address</string>
+    <string name="setting_menu_kand_title_socks5_port">SOCKS5 Proxy Port</string>
+    <string name="settings_menu_kand_title_bypass_address">Bypass Addresses</string>
+    <string name="setting_menu_kand_desc_bypass_address">Use CIDR to describe bypass addresses, separate each CIDR by a comma.</string>
 
     <string name="setting_menu_view_head">Kcanotify Settings</string>
     <string name="setting_menu_view_title_overlay_setting">Screen Overlay Settings</string>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -49,6 +49,28 @@
         android:key="download_data"
         android:summary="@string/setting_menu_kand_desc_game_data_down"
         android:title="@string/setting_menu_kand_title_game_data_down" />
+
+        <PreferenceScreen
+            android:title="@string/setting_menu_kand_title_adv_network">
+            <Preference
+                android:selectable="false"
+                android:persistent="false"
+                android:title=""
+                android:summary="@string/setting_menu_kand_warn_adv_network" />
+            <EditTextPreference
+                android:key="socks5_address"
+                android:title="@string/setting_menu_kand_title_socks5_address" />
+            <EditTextPreference
+                android:key="socks5_port"
+                android:inputType="numberDecimal"
+                android:title="@string/setting_menu_kand_title_socks5_port" />
+            <EditTextPreference
+                android:key="bypass_address"
+                android:title="@string/settings_menu_kand_title_bypass_address"
+                android:summary="@string/setting_menu_kand_desc_bypass_address" />
+        </PreferenceScreen>
+
+
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/setting_menu_view_head">
         <Preference


### PR DESCRIPTION
This commit allows users to change SOCKS5 proxy configurations and set bypass addresses for VPN service. It adds a subscreen named "Advanced Network Settings" including those settings into the application settings.
***
I'm considering adding "Bypass Applications" as well, which allows more control over VPN service.