### PR TITLE
fix crash for new quest type

### DIFF
--- a/app/src/main/java/com/antest1/kcanotify/KcaQuestListAdpater.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaQuestListAdpater.java
@@ -30,6 +30,7 @@ import static com.antest1.kcanotify.KcaApiData.getShipTypeAbbr;
 import static com.antest1.kcanotify.KcaApiData.isQuestTrackable;
 import static com.antest1.kcanotify.KcaApiData.kcQuestInfoData;
 import static com.antest1.kcanotify.KcaUtils.getId;
+import static com.antest1.kcanotify.KcaUtils.getIdWithFallback;
 import static com.antest1.kcanotify.KcaUtils.joinStr;
 
 public class KcaQuestListAdpater extends BaseAdapter {
@@ -118,7 +119,7 @@ public class KcaQuestListAdpater extends BaseAdapter {
             }
         }
 
-        holder.quest_category.setText(getStringWithLocale(getId(KcaUtils.format("quest_category_%d", api_category), R.string.class)));
+        holder.quest_category.setText(getStringWithLocale(getIdWithFallback(KcaUtils.format("quest_category_%d", api_category), "quest_category_10",  R.string.class)));
         holder.quest_category.setBackgroundColor(getQuestCategoryColor(api_category));
 
         holder.quest_type.setText(getQuestLabelString(api_label_type));
@@ -222,6 +223,8 @@ public class KcaQuestListAdpater extends BaseAdapter {
                         return (category == 1 || category == 5 || category == 7);
                     } else if (filter == 2) {
                         return (category == 2 || category == 8 || category == 9);
+                    } else if (filter == 6) {
+                        return (category == 6 || category == 11);
                     } else {
                         return (category == filter);
                     }
@@ -237,7 +240,7 @@ public class KcaQuestListAdpater extends BaseAdapter {
     }
 
     public int getQuestCategoryColor(int category) {
-        return ContextCompat.getColor(application_context, KcaUtils.getId(KcaUtils.format("colorQuestCategory%d", category), R.color.class));
+        return ContextCompat.getColor(application_context, KcaUtils.getIdWithFallback(KcaUtils.format("colorQuestCategory%d", category), "colorQuestCategory10", R.color.class));
     }
 
     public String getQuestLabelString(int label) {
@@ -245,12 +248,12 @@ public class KcaQuestListAdpater extends BaseAdapter {
             String format = getStringWithLocale(R.string.quest_label_type_100);
             return KcaUtils.format(format, label % 100);
         } else {
-            return getStringWithLocale(getId(KcaUtils.format("quest_label_type_%d", label), R.string.class));
+            return getStringWithLocale(getIdWithFallback(KcaUtils.format("quest_label_type_%d", label), "quest_label_type_07", R.string.class));
         }
     }
 
     public int getQuestLabelColor(int label) {
         if (label > 100 && label < 120) label = 100;
-        return ContextCompat.getColor(application_context, KcaUtils.getId(KcaUtils.format("colorQuestLabel%d", label), R.color.class));
+        return ContextCompat.getColor(application_context, KcaUtils.getIdWithFallback(KcaUtils.format("colorQuestLabel%d", label), "colorQuestLabel7", R.color.class));
     }
 }

--- a/app/src/main/java/com/antest1/kcanotify/KcaQuestListAdpater.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaQuestListAdpater.java
@@ -248,7 +248,7 @@ public class KcaQuestListAdpater extends BaseAdapter {
             String format = getStringWithLocale(R.string.quest_label_type_100);
             return KcaUtils.format(format, label % 100);
         } else {
-            return getStringWithLocale(getIdWithFallback(KcaUtils.format("quest_label_type_%d", label), "quest_label_type_07", R.string.class));
+            return getStringWithLocale(getIdWithFallback(KcaUtils.format("quest_label_type_%d", label), "quest_label_type_7", R.string.class));
         }
     }
 

--- a/app/src/main/java/com/antest1/kcanotify/KcaUtils.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaUtils.java
@@ -411,6 +411,15 @@ public class KcaUtils {
         return context.getResources().getResourceEntryName(resid);
     }
 
+    public static int getIdWithFallback(String resourceName, String fallbackResourceName, Class<?> c) {
+        try {
+            Field idField = c.getDeclaredField(resourceName);
+            return idField.getInt(idField);
+        } catch (Exception e) {
+            return getId(fallbackResourceName, c);
+        }
+    }
+
     public static int getId(String resourceName, Class<?> c) {
         try {
             Field idField = c.getDeclaredField(resourceName);

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -363,6 +363,7 @@
     <string name="quest_category_8">SB</string>
     <string name="quest_category_9">B</string>
     <string name="quest_category_10">N</string>
+    <string name="quest_category_11">F</string>
 
     <string name="quest_label_type_1">O</string>
     <string name="quest_label_type_2">D</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -354,6 +354,7 @@
     <string name="quest_category_8">出</string>
     <string name="quest_category_9">出</string>
     <string name="quest_category_10">他</string>
+    <string name="quest_category_11">工</string>
 
     <string name="quest_label_type_1">単</string>
     <string name="quest_label_type_2">日</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -360,6 +360,7 @@
     <string name="quest_category_8">출</string>
     <string name="quest_category_9">출</string>
     <string name="quest_category_10">타</string>
+    <string name="quest_category_11">공</string>
 
     <string name="quest_label_type_1">단</string>
     <string name="quest_label_type_2">일</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -381,6 +381,7 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
     <string name="quest_category_8">出</string>
     <string name="quest_category_9">出</string>
     <string name="quest_category_10">他</string>
+    <string name="quest_category_11">工</string>
 
     <string name="quest_label_type_1">单</string>
     <string name="quest_label_type_2">日</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -382,6 +382,7 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
     <string name="quest_category_8">出</string>
     <string name="quest_category_9">出</string>
     <string name="quest_category_10">他</string>
+    <string name="quest_category_11">工</string>
 
     <string name="quest_label_type_1">單</string>
     <string name="quest_label_type_2">日</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -94,6 +94,7 @@
     <color name="colorQuestCategory8">#d50000</color>
     <color name="colorQuestCategory9">#d50000</color>
     <color name="colorQuestCategory10">#757575</color>
+    <color name="colorQuestCategory11">#6d4c41</color>
 
     <color name="colorQuestLabel0">#616161</color>
     <color name="colorQuestLabel1">#fbc02e</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,6 +444,7 @@ https://github.com/antest1/kcanotify/blob/master/app/src/main/res/values/strings
     <string name="quest_category_8">SB</string>
     <string name="quest_category_9">B</string>
     <string name="quest_category_10">N</string>
+    <string name="quest_category_11">F</string>
 
     <string name="quest_label_type_0" formatted="false" translatable="false">\?</string>
     <string name="quest_label_type_1">O</string>


### PR DESCRIPTION
New factory quest added today "海軍工廠の再整備" has a new API category type of 11 which is not currently supported by KCANotify.

Here is a fix.

- add label and color resource for quest category 11 (copied factory category label)
- add a fallback logic to avoid crash for new categories/label_types in the future