### PR TITLE
fix equip item count

### DIFF
--- a/app/src/main/java/com/antest1/kcanotify/KcaApiData.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaApiData.java
@@ -355,7 +355,7 @@ public class KcaApiData {
         int max_equip_size = 0;
         JsonObject basic_info = helper.getJsonObjectValue(DB_KEY_BASICIFNO);
         if (basic_info != null) max_equip_size = basic_info.get("api_max_slotitem").getAsInt();
-        return max_equip_size <= getItemSize();
+        return max_equip_size <= getItemSizeWithExclusions();
     }
 
     public static boolean checkEventUserShip() {
@@ -370,7 +370,7 @@ public class KcaApiData {
         JsonObject basic_info = helper.getJsonObjectValue(DB_KEY_BASICIFNO);
         if (basic_info != null) max_item_size = basic_info.get("api_max_slotitem").getAsInt();
         //Log.e("KCA", KcaUtils.format("Item: %d - %d", maxItemSize, helper.getItemCount() + getItemCountInBattle));
-        return (max_item_size + 3) < (getItemSize() + 20);
+        return (max_item_size + 3) < (getItemSizeWithExclusions() + 20);
     }
 
 
@@ -466,6 +466,10 @@ public class KcaApiData {
     }
 
     public static int getItemSize() { return helper.getItemCount() + getItemCountInBattle; }
+
+    public static int getItemSizeWithExclusions() {
+        return helper.getItemCountWithExclusions() + getItemCountInBattle;
+    }
 
     private static JsonObject getJsonObjectFromStorage(Context context, String name) {
         return KcaUtils.getJsonObjectFromStorage(context, name, helper);

--- a/app/src/main/java/com/antest1/kcanotify/KcaDBHelper.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaDBHelper.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteStatement;
@@ -316,6 +317,22 @@ public class KcaDBHelper extends SQLiteOpenHelper {
         return result;
     }
 
+    /**
+     * same as {@link #getItemCount()} but excluding these items:
+     * 42: 応急修理要員
+     * 43: 応急修理女神
+     * 145: 戦闘糧食
+     * 146: 洋上補給
+     * 150: 秋刀魚の缶詰
+     * 241: 戦闘糧食(特別なおにぎり)
+     */
+    public int getItemCountWithExclusions() {
+        try (SQLiteDatabase db = getReadableDatabase()) {
+            return (int) DatabaseUtils.queryNumEntries(db,
+                    slotitem_table_name,
+                    "KCID NOT IN(42, 43, 145, 146, 150, 241)");
+        }
+    }
 
     public int getItemCountByKcId(int id) {
         int result = 0;

--- a/app/src/main/java/com/antest1/kcanotify/KcaFleetViewService.java
+++ b/app/src/main/java/com/antest1/kcanotify/KcaFleetViewService.java
@@ -203,7 +203,7 @@ public class KcaFleetViewService extends Service {
                             R.color.white), PorterDuff.Mode.MULTIPLY);
                 }
 
-                equipcntview.setText(KcaUtils.format("%d/%d", KcaApiData.getItemSize(), KcaApiData.getUserMaxItemCount()));
+                equipcntview.setText(KcaUtils.format("%d/%d", KcaApiData.getItemSizeWithExclusions(), KcaApiData.getUserMaxItemCount()));
                 if (KcaApiData.checkEventUserItem()){
                     equipcntview.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.colorHqCheckEventCondFailed));
                     equipcntviewicon.setColorFilter(ContextCompat.getColor(getApplicationContext(),


### PR DESCRIPTION
fix #92
- added `KcaDBHelper#getItemCountWithExclusions()` and `KcaApiData#getItemSizeWithExclusions()`
- replaced some use cases of `KcaDBHelper#getItemCount()` and `KcaApiData#getItemSize()`

known weaknesses: 
- if new rations, damcon, or oil supplies are added, they will not be excluded
- items that got while sortie will not be excluded